### PR TITLE
修复 QR 码不正确的问题

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -107,7 +107,7 @@ class HomeController extends Controller
     {
         $port = $request->get('port');
         $user = Member::where('port', $port)->first();
-        $temp = 'aes-256-cfb:' . $user->password . \Config::get('app.ss_domain') . $user->port;
+        $temp = 'aes-256-cfb:' . $user->password .'@'. \Config::get('app.ss_domain') . ':'. $user->port;
         $qr_url = 'ss://' . base64_encode($temp);
         $total = Flow::getTotalFlow($port);
         $day_flow = $this->getThisDayFlow($port);


### PR DESCRIPTION
QR 码的格式为 ss://协议+ ":"+密码+”@“+IP+":"+端口